### PR TITLE
Make coverage on src rather than transpiled

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "playground": "node devServer.js",
     "prepublish": "npm run build",
     "lint": "eslint src/Slider.jsx src/utils/*.js",
-    "test": "npm run build && npm run lint && npm run test:coverage",
-    "test:coverage": "babel-node node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -R tap test/*-test.js",
+    "test": "npm run lint && npm run test:coverage",
+    "test:coverage": "babel-node node_modules/.bin/babel-istanbul cover node_modules/.bin/_mocha -- -R tap test/*-test.js",
     "test:quick": "babel-node node_modules/.bin/_mocha -R tap test/*-test.js"
   },
   "repository": {

--- a/test/slider-test.js
+++ b/test/slider-test.js
@@ -1,6 +1,6 @@
 import { shallow, describeWithDOM, mount } from 'enzyme';
 import React from 'react';
-import Slider from '../';
+import Slider from '../src/Slider';
 import sinon from 'sinon';
 import { assert } from 'chai';
 import { KEYS } from '../lib/constants/SliderConstants';


### PR DESCRIPTION
to @ljharb 

This uses babel-istanbul and pulls from src instead of lib so the coverage can display the original source instead of the transpiled one.
