### PR TITLE
Add a prop for disabling the slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ The values, by default 0 and 100.
   values: PropTypes.arrayOf(PropTypes.number)
 ```
 
+You can disable the slider to prevent the user from moving it.
+
+```js
+  disabled: PropTypes.bool
+```
+
 ## Usage
 
 > Important: Make sure to include the [css file](css/slider.css) or feel free to create your own.

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -127,10 +127,6 @@ export default React.createClass({
 
     const disabledChanged = nextProps.disabled !== this.props.disabled;
 
-    if (disabledChanged) {
-      this.endSlide();
-    }
-
     if (orientationChanged) {
       this.setState({
         className: getClassName(nextProps),
@@ -138,6 +134,10 @@ export default React.createClass({
     }
 
     if (minMaxChanged || valuesChanged) this.updateNewValues(nextProps);
+
+    if (disabledChanged) {
+      this.endSlide();
+    }
   },
 
   getPublicState() {

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -125,7 +125,7 @@ export default React.createClass({
       nextProps.orientation !== this.props.orientation
     );
 
-    const disabledChanged = nextProps.disabled !== this.props.disabled;
+    const willBeDisabled = nextProps.disabled && !this.props.disabled;
 
     if (orientationChanged) {
       this.setState({
@@ -135,7 +135,7 @@ export default React.createClass({
 
     if (minMaxChanged || valuesChanged) this.updateNewValues(nextProps);
 
-    if (disabledChanged) {
+    if (willBeDisabled && this.state.slidingIndex !== null) {
       this.endSlide();
     }
   },

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -334,10 +334,6 @@ export default React.createClass({
 
   // istanbul ignore next
   startMouseSlide(ev) {
-    if (this.props.disabled) {
-      return;
-    }
-
     this.setStartSlide(ev, ev.clientX, ev.clientY);
 
     if (typeof document.addEventListener === 'function') {
@@ -353,10 +349,6 @@ export default React.createClass({
 
   // istanbul ignore next
   startTouchSlide(ev) {
-    if (this.props.disabled) {
-      return;
-    }
-
     if (ev.changedTouches.length > 1) return;
 
     const touch = ev.changedTouches[0];
@@ -437,10 +429,6 @@ export default React.createClass({
 
   // istanbul ignore next
   handleClick(ev) {
-    if (this.props.disabled) {
-      return;
-    }
-
     // if we're coming off of the end of a slide don't handle the click also
     if (this.state.slidingIndex === -1) {
       this.setState({ slidingIndex: null });
@@ -473,10 +461,6 @@ export default React.createClass({
 
   // istanbul ignore next
   handleKeydown(ev) {
-    if (this.props.disabled) {
-      return;
-    }
-
     const idx = this.getHandleFor(ev);
 
     if (ev.keyCode === SliderConstants.KEYS.ESC) {
@@ -597,11 +581,13 @@ export default React.createClass({
   },
 
   render() {
+    const disabled = this.props.disabled;
+
     return (
       <div
         className={this.state.className}
         ref="rheostat"
-        onClick={this.handleClick}
+        onClick={!disabled && this.handleClick}
         style={{ position: 'relative' }}
       >
         <div className="rheostat-background" />
@@ -615,13 +601,13 @@ export default React.createClass({
               aria-valuemax={this.getMaxValue(idx)}
               aria-valuemin={this.getMinValue(idx)}
               aria-valuenow={this.state.values[idx]}
-              aria-disabled={this.props.disabled}
+              aria-disabled={disabled}
               data-handle-key={idx}
               className="rheostat-handle"
               key={idx}
-              onKeyDown={this.handleKeydown}
-              onMouseDown={this.startMouseSlide}
-              onTouchStart={this.startTouchSlide}
+              onKeyDown={!disabled && this.handleKeydown}
+              onMouseDown={!disabled && this.startMouseSlide}
+              onTouchStart={!disabled && this.startTouchSlide}
               role="slider"
               style={handleStyle}
               tabIndex={this.props.handleTabIndexStart + idx}

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -29,6 +29,8 @@ export default React.createClass({
     children: PropTypes.any,
     // standard class name you'd like to apply to the root element
     className: PropTypes.string,
+    // prevent the slider from moving when clicked
+    disabled: PropTypes.bool,
     // a custom handle you can pass in
     handle: PropTypeReactComponent,
     // the tab index to start each handler on
@@ -72,6 +74,7 @@ export default React.createClass({
     return {
       algorithm: linear,
       className: '',
+      disabled: false,
       handle: 'div',
       handleTabIndexStart: 1,
       max: SliderConstants.PERCENT_FULL,
@@ -121,6 +124,12 @@ export default React.createClass({
       nextProps.className !== this.props.className ||
       nextProps.orientation !== this.props.orientation
     );
+
+    const disabledChanged = nextProps.disabled !== this.props.disabled;
+
+    if (disabledChanged) {
+      this.endSlide();
+    }
 
     if (orientationChanged) {
       this.setState({
@@ -325,6 +334,10 @@ export default React.createClass({
 
   // istanbul ignore next
   startMouseSlide(ev) {
+    if (this.props.disabled) {
+      return;
+    }
+
     this.setStartSlide(ev, ev.clientX, ev.clientY);
 
     if (typeof document.addEventListener === 'function') {
@@ -335,11 +348,15 @@ export default React.createClass({
       document.attachEvent('onmouseup', this.endSlide);
     }
 
-    return this.killEvent(ev);
+    this.killEvent(ev);
   },
 
   // istanbul ignore next
   startTouchSlide(ev) {
+    if (this.props.disabled) {
+      return;
+    }
+
     if (ev.changedTouches.length > 1) return;
 
     const touch = ev.changedTouches[0];
@@ -420,6 +437,10 @@ export default React.createClass({
 
   // istanbul ignore next
   handleClick(ev) {
+    if (this.props.disabled) {
+      return;
+    }
+
     // if we're coming off of the end of a slide don't handle the click also
     if (this.state.slidingIndex === -1) {
       this.setState({ slidingIndex: null });
@@ -452,6 +473,10 @@ export default React.createClass({
 
   // istanbul ignore next
   handleKeydown(ev) {
+    if (this.props.disabled) {
+      return;
+    }
+
     const idx = this.getHandleFor(ev);
 
     if (ev.keyCode === SliderConstants.KEYS.ESC) {
@@ -590,6 +615,7 @@ export default React.createClass({
               aria-valuemax={this.getMaxValue(idx)}
               aria-valuemin={this.getMinValue(idx)}
               aria-valuenow={this.state.values[idx]}
+              aria-disabled={this.props.disabled}
               data-handle-key={idx}
               className="rheostat-handle"
               key={idx}

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -582,6 +582,18 @@ export default React.createClass({
 
   render() {
     const disabled = this.props.disabled;
+    const {
+      algorithm,
+      children,
+      handle: Handle,
+      handleTabIndexStart,
+      max,
+      min,
+      orientation,
+      pitComponent: PitComponent,
+      pitPoints,
+      progressBar: ProgressBar,
+    } = this.props;
 
     return (
       <div
@@ -592,12 +604,12 @@ export default React.createClass({
       >
         <div className="rheostat-background" />
         {this.state.handlePos.map((pos, idx) => {
-          const handleStyle = this.props.orientation === 'vertical'
+          const handleStyle = orientation === 'vertical'
             ? { top: `${pos}%`, position: 'absolute' }
             : { left: `${pos}%`, position: 'absolute' };
 
           return (
-            <this.props.handle
+            <Handle
               aria-valuemax={this.getMaxValue(idx)}
               aria-valuemin={this.getMinValue(idx)}
               aria-valuenow={this.state.values[idx]}
@@ -610,7 +622,7 @@ export default React.createClass({
               onTouchStart={!disabled && this.startTouchSlide}
               role="slider"
               style={handleStyle}
-              tabIndex={this.props.handleTabIndexStart + idx}
+              tabIndex={handleTabIndexStart + idx}
             />
           );
         })}
@@ -620,24 +632,24 @@ export default React.createClass({
           }
 
           return (
-            <this.props.progressBar
+            <ProgressBar
               className="rheostat-progress"
               key={idx}
               style={this.getProgressStyle(idx)}
             />
           );
         })}
-        {this.props.pitComponent && this.props.pitPoints.map((n) => {
-          const pos = this.props.algorithm.getPosition(n, this.props.min, this.props.max);
-          const pitStyle = this.props.orientation === 'vertical'
+        {PitComponent && pitPoints.map((n) => {
+          const pos = algorithm.getPosition(n, min, max);
+          const pitStyle = orientation === 'vertical'
             ? { top: `${pos}%`, position: 'absolute' }
             : { left: `${pos}%`, position: 'absolute' };
 
           return (
-            <this.props.pitComponent key={n} style={pitStyle}>{n}</this.props.pitComponent>
+            <PitComponent key={n} style={pitStyle}>{n}</PitComponent>
           );
         })}
-        {this.props.children}
+        {children}
       </div>
     );
   },

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -581,10 +581,10 @@ export default React.createClass({
   },
 
   render() {
-    const disabled = this.props.disabled;
     const {
       algorithm,
       children,
+      disabled,
       handle: Handle,
       handleTabIndexStart,
       max,

--- a/stories/ExampleSlider.jsx
+++ b/stories/ExampleSlider.jsx
@@ -178,5 +178,8 @@ storiesOf('Slider', module)
   ))
   .add('Vertical', () => (
     <LabeledSlider orientation="vertical" />
+  ))
+  .add('Disabled', () => (
+    <LabeledSlider disabled />
   ));
 


### PR DESCRIPTION
Fairly self-explanatory, prevents the user from moving the slider handles when `disabled=true`. I believe this covers the case where the user is moving the handle when it gets disabled, in which case it behaves like a standard HTML slider and stops in place.