### PR TITLE
Fixes rheostat for React 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint src/Slider.jsx src/utils/*.js",
     "storybook": "start-storybook -p 9001",
     "test": "npm run build && npm run lint && npm run test:coverage",
-    "test:coverage": "babel-node node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -R tap 'test/**/*-test.js'",
+    "test:coverage": "babel-node node_modules/.bin/babel-istanbul cover node_modules/.bin/_mocha -- -R tap 'test/**/*-test.js'",
     "test:quick": "babel-node node_modules/.bin/_mocha -R tap test/*-test.js"
   },
   "repository": {

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -2,11 +2,6 @@ import * as SliderConstants from './constants/SliderConstants';
 import React, { PropTypes } from 'react';
 import linear from './algorithms/linear';
 
-// istanbul ignore next
-function getDOMNode(node) {
-  return React.version.indexOf('0.14') > -1 ? node : node.getDOMNode();
-}
-
 function getClassName(props) {
   const orientation = props.orientation === 'vertical'
     ? 'rheostat-vertical'
@@ -150,7 +145,8 @@ export default React.createClass({
 
   // istanbul ignore next
   getSliderBoundingBox() {
-    const node = getDOMNode(this.refs.rheostat);
+    const { rheostat } = this.refs;
+    const node = rheostat.getDOMNode ? rheostat.getDOMNode() : rheostat;
     const rect = node.getBoundingClientRect();
 
     return {


### PR DESCRIPTION
Lets just use getDOMNode if its available and if its not then we'll assume that the ref is the node itself. This gets rid of the React.version hack. Plus now we're compatible with AFAICT React 12+

@ljharb 