### PR TITLE
Sets tabIndex to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,6 @@ Custom class name that will be applied to the root of Rheostat.
   className: PropTypes.string
 ```
 
-The tab index to start the first handle on, by default 1. Successive handles will have a tabIndex
-of consecutive increasing order.
-
-```js
-  handleTabIndexStart: PropTypes.number
-```
-
 Custom React component overrides for both the handles, and the "progress" bar.
 
 ```js

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -28,8 +28,6 @@ export default React.createClass({
     disabled: PropTypes.bool,
     // a custom handle you can pass in
     handle: PropTypeReactComponent,
-    // the tab index to start each handler on
-    handleTabIndexStart: PropTypes.number,
     // the maximum possible value
     max: PropTypes.number,
     // the minimum possible value
@@ -71,7 +69,6 @@ export default React.createClass({
       className: '',
       disabled: false,
       handle: 'div',
-      handleTabIndexStart: 1,
       max: SliderConstants.PERCENT_FULL,
       min: SliderConstants.PERCENT_EMPTY,
       orientation: 'horizontal',
@@ -582,7 +579,6 @@ export default React.createClass({
       children,
       disabled,
       handle: Handle,
-      handleTabIndexStart,
       max,
       min,
       orientation,
@@ -618,7 +614,7 @@ export default React.createClass({
               onTouchStart={!disabled && this.startTouchSlide}
               role="slider"
               style={handleStyle}
-              tabIndex={handleTabIndexStart + idx}
+              tabIndex={0}
             />
           );
         })}


### PR DESCRIPTION
@backwardok @ljharb 

Hardcoding the tab index to 0 so it addresses the tabbing issue. This removes the previous behavior of having the tab index be configurable. That's ok because it seems like it is best practice to always set to 0 and let DOM layout structure dictate how elements are tabbed to.

More info here: http://webaim.org/techniques/keyboard/tabindex