### PR TITLE
Adds aria-label to default button slider handle

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -29,7 +29,7 @@ function killEvent(ev) {
 
 class Button extends React.Component {
   render() {
-    return <button {...this.props} type="button" />;
+    return <button {...this.props} aria-label="Slider Handle" type="button" />;
   }
 }
 
@@ -620,10 +620,10 @@ class Rheostat extends React.Component {
 
           return (
             <Handle
+              aria-disabled={disabled}
               aria-valuemax={this.getMaxValue(idx)}
               aria-valuemin={this.getMinValue(idx)}
               aria-valuenow={this.state.values[idx]}
-              aria-disabled={disabled}
               data-handle-key={idx}
               className="rheostat-handle"
               key={idx}


### PR DESCRIPTION
We've changed slider handles to be a button but we did not add any
discernible text to the button to aid screen reader users. This commit adds an
aria-label to the default handles.

@ljharb @backwardok