### PR TITLE
[Fix] use prop-types package + replace React.createClass

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "casual": "^1.5.8",
     "chai": "^3.5.0",
     "chai-enzyme": "^0.6.1",
+    "create-react-class": "^15.5.2",
     "enzyme": "^1.6.0",
     "eslint": "^3.13.1",
     "eslint-config-airbnb": "^14.0.0",
@@ -53,5 +54,8 @@
   },
   "peerDependencies": {
     "react": ">=0.13.x"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.6"
   }
 }

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -1,7 +1,8 @@
 /* globals document */
 /* eslint react/no-array-index-key: 1 */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import * as SliderConstants from './constants/SliderConstants';
 import linear from './algorithms/linear';

--- a/test/slider-test.jsx
+++ b/test/slider-test.jsx
@@ -1,5 +1,7 @@
 import { shallow, describeWithDOM, mount } from 'enzyme';
 import React from 'react';
+import createReactClass from 'create-react-class';
+
 import sinon from 'sinon';
 import { assert } from 'chai';
 import has from 'has';
@@ -41,9 +43,7 @@ describeWithDOM('<Slider />', () => {
 
     it('renders pits if they are provided', () => {
       const pitRender = sinon.stub().returns(<div />);
-
-      // eslint-disable-next-line
-      const PitComponent = React.createClass({
+      const PitComponent = createReactClass({
         render: pitRender,
       });
 
@@ -54,9 +54,7 @@ describeWithDOM('<Slider />', () => {
 
     it('renders pits if they are provided', () => {
       const pitRender = sinon.stub().returns(<div />);
-
-      // eslint-disable-next-line
-      const PitComponent = React.createClass({
+      const PitComponent = createReactClass({
         render: pitRender,
       });
 


### PR DESCRIPTION
- Use `prop-types` package instead of `React.PropTypes`
- Replace `React.createClass` with `create-react-class`

