### PR TITLE
Fire 'onSliderDragStart' on mouse down

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -376,6 +376,8 @@ class Rheostat extends React.Component {
       document.attachEvent('onmouseup', this.endSlide);
     }
 
+    if (this.props.onSliderDragStart) this.props.onSliderDragStart();
+
     killEvent(ev);
   }
 

--- a/test/slider-test.jsx
+++ b/test/slider-test.jsx
@@ -171,6 +171,24 @@ describe('<Slider />', () => {
       assert(slider.state('handlePos').length === 2, 'two handles exist');
     });
   });
+
+  it('fires onSliderDragStart when clicked or touched', () => {
+    const onSliderDragStart = sinon.spy();
+    const wrapper = mount(<Slider onSliderDragStart={onSliderDragStart} values={[50]} />);
+    const handle = wrapper.find('.rheostat-handle');
+    handle.simulate('mouseDown', { clientX: 0, clientY: 0 });
+    assert(onSliderDragStart.callCount === 1, 'onDragStart was called from mouseDown');
+    const touchProps = {
+      changedTouches: [
+        {
+          clientX: 0,
+          clientY: 0,
+        },
+      ],
+    };
+    handle.simulate('touchStart', touchProps);
+    assert(onSliderDragStart.callCount === 2, 'onDragStart was called from touchStart');
+  });
 });
 
 describe('Slider API', () => {


### PR DESCRIPTION
I noticed that `onSliderDragStart` is fired on touch start but not on mouse down. Currently there seems to be no way to capture a mouseDown event on the slider. If there's another handler I should be using, feel free to point me to that and close this PR.