### PR TITLE
Give drag start event object

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -376,7 +376,7 @@ class Rheostat extends React.Component {
       document.attachEvent('onmouseup', this.endSlide);
     }
 
-    if (this.props.onSliderDragStart) this.props.onSliderDragStart();
+    if (this.props.onSliderDragStart) this.props.onSliderDragStart(ev);
 
     killEvent(ev);
   }
@@ -392,7 +392,7 @@ class Rheostat extends React.Component {
     document.addEventListener('touchmove', this.handleTouchSlide, false);
     document.addEventListener('touchend', this.endSlide, false);
 
-    if (this.props.onSliderDragStart) this.props.onSliderDragStart();
+    if (this.props.onSliderDragStart) this.props.onSliderDragStart(ev);
 
     killEvent(ev);
   }

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -376,6 +376,8 @@ class Rheostat extends React.Component {
       document.attachEvent('onmouseup', this.endSlide);
     }
 
+    if (this.props.onSliderDragStart) this.props.onSliderDragStart();
+
     killEvent(ev);
   }
 

--- a/test/slider-test.jsx
+++ b/test/slider-test.jsx
@@ -171,6 +171,24 @@ describe('<Slider />', () => {
       assert(slider.state('handlePos').length === 2, 'two handles exist');
     });
   });
+
+  it('fires onSliderDragStart when clicked or touched', () => {
+    const onSliderDragStart = sinon.spy();
+    const wrapper = mount(<Slider onSliderDragStart={onSliderDragStart} values={[50]} />);
+    const handle = wrapper.find('.rheostat-handle');
+    handle.simulate('mouseDown', { clientX: 0, clientY: 0 });
+    assert(onSliderDragStart.callCount === 1, 'onDragStart was called from mouseDown');
+    const touchProps = {
+      changedTouches: [
+        {
+          clientX: 0,
+          clientY: 0,
+        },
+      ],
+    };
+    handle.simulate('touchStart', touchProps);
+    assert(onSliderDragStart.callCount === 2, 'onDragStart was called from touchStart');
+  });
 });
 
 describe('Slider API', () => {

--- a/test/slider-test.jsx
+++ b/test/slider-test.jsx
@@ -178,6 +178,7 @@ describe('<Slider />', () => {
     const handle = wrapper.find('.rheostat-handle');
     handle.simulate('mouseDown', { clientX: 0, clientY: 0 });
     assert(onSliderDragStart.callCount === 1, 'onDragStart was called from mouseDown');
+    assert(onSliderDragStart.calledWith({ clientX: 0, clientY: 0 }));
     const touchProps = {
       changedTouches: [
         {
@@ -188,6 +189,7 @@ describe('<Slider />', () => {
     };
     handle.simulate('touchStart', touchProps);
     assert(onSliderDragStart.callCount === 2, 'onDragStart was called from touchStart');
+    assert(onSliderDragStart.calledWith(touchProps));
   });
 });
 


### PR DESCRIPTION
This relies on @pkenway 's PR, https://github.com/airbnb/rheostat/pull/77

Rheostat already gives the clientX/clientY on `handleDrag`, but it doesn't give it on DragStart. Unfortunately that means that if the user clicks on a slider, but doesn't move their mouse or finger, then we won't know where the clientX/clientY is.

This PR fixes that!