### PR TITLE
fix(Slider): avoid key={0}

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -643,7 +643,7 @@ class Rheostat extends React.Component {
               aria-disabled={disabled}
               data-handle-key={idx}
               className="rheostat-handle"
-              key={idx}
+              key={`handle-${idx}`}
               onClick={this.killEvent}
               onKeyDown={!disabled && this.handleKeydown}
               onMouseDown={!disabled && this.startMouseSlide}
@@ -662,7 +662,7 @@ class Rheostat extends React.Component {
           return (
             <ProgressBar
               className="rheostat-progress"
-              key={idx}
+              key={`progress-bar-${idx}`}
               style={this.getProgressStyle(idx)}
             />
           );
@@ -674,7 +674,7 @@ class Rheostat extends React.Component {
             : { left: `${pos}%`, position: 'absolute' };
 
           return (
-            <PitComponent key={n} style={pitStyle}>{n}</PitComponent>
+            <PitComponent key={`pit-${n}`} style={pitStyle}>{n}</PitComponent>
           );
         })}
         {children}


### PR DESCRIPTION
Hello,

When you are using with [preact](https://github.com/developit/preact) issues can happen when you have an element with the `key={0}`

see: 

* https://github.com/developit/preact/issues/642
* https://github.com/algolia/instantsearch.js/issues/2293

It is a "temporary" fix to make the library used until the issue is originally fixed into preact.