### PR TITLE
Add getNextHandlePosition for complex drag validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Add getNextHandlePosition prop to allow custom movement validation
+
 ## [2.1.3] - 2018-01-03
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ a drag, keypress, or click event. `onChange` is recommended when you wish to per
 changed. This includes dragging, click, or keypress. `onValuesUpdated` is recommended if you need
 to work with the values before they're committed.
 
+If you need to perform custom logic to postprocess the handle position, `getNextHandlePosition` accepts
+a callback of the form `(handleIdx: int, percentPosition: float) => float`. Return the updated
+handle position. This is useful if you need to customize ranges within a single slider.
+
 ```js
   onChange: PropTypes.func
   onClick: PropTypes.func
@@ -64,6 +68,7 @@ to work with the values before they're committed.
   onSliderDragMove: PropTypes.func
   onSliderDragStart: PropTypes.func
   onValuesUpdated: PropTypes.func
+  getNextHandlePosition: PropTypes.func
 ```
 
 `snap` is a boolean which controls the slider's snapping behavior.

--- a/test/slider-test.jsx
+++ b/test/slider-test.jsx
@@ -574,6 +574,46 @@ describe('Slider API', () => {
       assert(slider.validatePosition(0, 90) === 75, 'the handle reached its own max');
       assert(slider.validatePosition(1, 20) === 25, 'the handle reached its own min');
     });
+
+    it('should honor getNextHandlePosition precondition', () => {
+      const LEFT_MAX = 40;
+      const LEFT_HANDLE_IDX = 0;
+      const slider = newSlider({
+        values: [30],
+        getNextHandlePosition: (idx, pos) =>
+          (idx === LEFT_HANDLE_IDX && pos > LEFT_MAX ? LEFT_MAX : pos),
+      });
+
+
+      assert(slider.validatePosition(0, 90) === 40, 'it honors the validatePosition override');
+      assert(slider.validatePosition(0, 39) === 39, 'accepts the default value when condition is not triggered');
+    });
+
+    it('should throw if getNextHandlePosition returns invalid input', () => {
+      const nanSlider = newSlider({
+        values: [30],
+        getNextHandlePosition: () => NaN,
+      });
+
+      assert.throws(
+        () => nanSlider.validatePosition(0, 100),
+        TypeError,
+        'getNextHandlePosition returned invalid position. Valid positions are floats between 0 and 100',
+        'it throws if a non - float is returns from getNextHandlePosition',
+      );
+
+      const outOfBoundsSlider = newSlider({
+        values: [30],
+        getNextHandlePosition: () => -100,
+      });
+
+      assert.throws(
+        () => outOfBoundsSlider.validatePosition(0, 100),
+        TypeError,
+        'getNextHandlePosition returned invalid position. Valid positions are floats between 0 and 100',
+        'it throws if getNextHandlePosition returns out of bounds',
+      );
+    });
   });
 
   describe('validateValues', () => {


### PR DESCRIPTION
Addresses https://github.com/airbnb/rheostat/issues/125. Allows us to deny a move depending on the handle index and next value.