### PR TITLE
Use math.round instead of math.floor for getting value with geomotric

### DIFF
--- a/src/algorithms/geometric.js
+++ b/src/algorithms/geometric.js
@@ -4,6 +4,6 @@ export default {
   },
 
   getValue(x, min, max) {
-    return (Math.floor(((x / 100) ** 2) * (max - min)) + min);
+    return (Math.round(((x / 100) ** 2) * (max - min)) + min);
   },
 };

--- a/test/algorithms/geometric-test.js
+++ b/test/algorithms/geometric-test.js
@@ -12,6 +12,14 @@ describe('geometric algorithm', () => {
     assert.equal(Math.round(positionFromValue), originalPosition);
   });
 
+  it('should have inverse functions for getValue and getPosition', () => {
+    const min = 10;
+    const max = 1000;
+    const value = 358;
+    const positionFromValue = geometric.getPosition(value, min, max);
+    assert.equal(value, geometric.getValue(positionFromValue, min, max));
+  });
+
   it('should handle the minimum end of the range correctly', () => {
     const min = casual.integer(0, 99);
     const max = casual.integer(100, 1000);


### PR DESCRIPTION
Use `Math.round` instead of `Math.floor` for getting values to fix small increments in positions might not be reflected in the values.

without the fix, the test will fail and yield 357 instead

JIRA comments:

hi @goatslacker , after some debug, I found this bug is due to the Math.floor is being used here. https://github.com/airbnb/rheostat/commit/ac671f34f8bff13579b3fa00e038a2627abc37d2#diff-18b3b4532ad02a3a1b4f629dcd1cebf4R7

 

If I change it to Math.round it will just work for keyboard press. The reason for the bug is that when value gets larger but not large enough, it gets floored back to the same number. Let me know what you think the best approach here. 


