### PR TITLE
Fixes React 16 prop-type Errors

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -702,7 +702,7 @@ class Rheostat extends React.Component {
       <div
         className={className}
         ref={this.setRef}
-        onClick={!disabled && this.handleClick}
+        onClick={!disabled ? this.handleClick : undefined}
         style={{ position: 'relative' }}
       >
         <div className="rheostat-background" />
@@ -721,9 +721,9 @@ class Rheostat extends React.Component {
               className="rheostat-handle"
               key={`handle-${idx}`}
               onClick={this.killEvent}
-              onKeyDown={!disabled && this.handleKeydown}
-              onMouseDown={!disabled && this.startMouseSlide}
-              onTouchStart={!disabled && this.startTouchSlide}
+              onKeyDown={!disabled ? this.handleKeydown : undefined}
+              onMouseDown={!disabled ? this.startMouseSlide : undefined}
+              onTouchStart={!disabled ? this.startTouchSlide : undefined}
               role="slider"
               style={handleStyle}
               tabIndex={0}

--- a/test/slider-test.jsx
+++ b/test/slider-test.jsx
@@ -86,6 +86,27 @@ describeWithDOM('<Slider />', () => {
 
       assert.isTrue(pitRender.calledOnce, 'one pit was rendered only once');
     });
+
+    it('should not throw react errors on disabled', () => {
+      const consoleErrorMock = sinon.spy(console, 'error');
+      const slider = mount(<Slider />);
+      slider.setProps({ disabled: true });
+      sinon.assert.callCount(consoleErrorMock, 0);
+    });
+
+    it('should pass undefined to key and mouse event handlers on disabled', () => {
+      const slider = mount(<Slider disabled />);
+      assert.isUndefined(slider.find('.rheostat-handle').first().props().onKeyDown, 'onKeyDown is undefined');
+      assert.isUndefined(slider.find('.rheostat-handle').first().props().onMouseDown, 'onMouseDown is undefined');
+      assert.isUndefined(slider.find('.rheostat-handle').first().props().onTouchStart, 'onTouchStart is undefined');
+    });
+
+    it('should pass functions to key and mouse event handlers', () => {
+      const slider = mount(<Slider />);
+      assert.isFunction(slider.find('.rheostat-handle').first().props().onKeyDown, 'onKeyDown is function');
+      assert.isFunction(slider.find('.rheostat-handle').first().props().onMouseDown, 'onMouseDown is function');
+      assert.isFunction(slider.find('.rheostat-handle').first().props().onTouchStart, 'onTouchStart is function');
+    });
   });
 
   describe('componentWillReceiveProps', () => {


### PR DESCRIPTION
When the component is started in a React 16 environment and the `disabled` prop is set to true, React 16 will throw a console warning for each of the functions set via the short circuit logical operators. 

This currently manifests as the following (subset) of warnings logged as console errors:
![image](https://user-images.githubusercontent.com/4111032/35599091-1454b07a-05f5-11e8-924a-b3a4c789f414.png)

This PR acts to silence those warnings and prep for the anticipation that React 17 will convert these to throwable errors. Documentation of the changes that introduced these warnings can be found [here](https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html#changes-in-detail) under "Non-boolean attributes with boolean values"

