### PR TITLE
Add tooltip

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -3,6 +3,7 @@ import { configure } from '@kadira/storybook';
 import '../css/slider.css';
 import '../css/slider-horizontal.css';
 import '../css/slider-vertical.css';
+import '../css/slider-tooltip.css';
 
 function loadStories() {
   require('../stories/ExampleSlider.jsx');

--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ The maximum and minimum possible values, by default 0 - 100.
   min: PropTypes.number
 ```
 
+You can enable a tooltip that appears above the handle.
+`handleTooltipComponent` is a custom React component for rendering "tooltip".
+```js
+  handleTooltip: PropTypes.bool
+  handleTooltipComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.string]);
+```
+
+If you need to format tooltip value, you can pass your custom function.
+```js
+  formatTooltipValue: PropTypes.func
+```
+
 `pitComponent` is a custom React component for rendering "pits" across the bar.
 `pitPoints` is the set of points at which it will render a pit. Points are an array
 of `values` on the slider.
@@ -120,6 +132,23 @@ ReactDOM.render((
   />
 ), document.getElementById('slider-root'));
 ```
+
+* A slider with tooltip
+
+```js
+import Rheostat from 'rheostat';
+
+ReactDOM.render((
+  <Rheostat
+    min={1}
+    max={100}
+    values={[75]}
+    handleTooltip
+  />
+), document.getElementById('slider-root'));
+```
+
+> Important: Make sure to include the [css file](css/slider-tooltip.css) for tooltip or feel free to create your own.
 
 ## Live Playground
 

--- a/css/slider-tooltip.css
+++ b/css/slider-tooltip.css
@@ -1,0 +1,33 @@
+.rheostat-handle {
+  position: relative;
+}
+
+.rheostat-handle-tooltip {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  -webkit-transform: translateX(-50%);
+  -moz-transform: translateX(-50%);
+  transform: translateX(-50%);
+  width: auto;
+  color: #fff;
+  padding: 5px 7px;
+  margin-bottom: 10px;
+  background-color: rgba(0, 0, 0, .6);
+  border-radius: 3px;
+}
+
+.rheostat-handle-tooltip:after {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  -webkit-transform: translateX(-50%);
+  -moz-transform: translateX(-50%);
+  transform: translateX(-50%);
+  border-top: 5px solid rgba(0, 0, 0, .6);
+  border-right: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 5px solid transparent;
+}

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" type="text/css" href="/css/slider.css" />
   <link rel="stylesheet" type="text/css" href="/css/slider-horizontal.css" />
   <link rel="stylesheet" type="text/css" href="/css/slider-vertical.css" />
+  <link rel="stylesheet" type="text/css" href="/css/slider-tooltip.css" />
 </head>
 <body>
   <div id="root"></div>

--- a/stories/ExampleSlider.jsx
+++ b/stories/ExampleSlider.jsx
@@ -153,6 +153,40 @@ storiesOf('Slider', module)
       values={[10]}
     />
   ))
+  .add('Tooltip', () => (
+    <LabeledSlider
+      min={1}
+      max={100}
+      values={[50]}
+      handleTooltip
+    />
+  ))
+  .add('Tooltip (with many handles)', () => (
+    <LabeledSlider
+      min={1}
+      max={100}
+      values={[50, 75]}
+      handleTooltip
+    />
+  ))
+  .add('Tooltip (with formatting)', () => {
+    function formatTooltipValue(value) {
+      return (value).toLocaleString('en-US', {
+        style: 'currency',
+        currency: 'USD',
+      });
+    }
+
+    return (
+      <LabeledSlider
+        min={1}
+        max={200}
+        values={[100]}
+        handleTooltip
+        formatTooltipValue={formatTooltipValue}
+      />
+    );
+  })
   .add('Pits', () => {
     function PitComponent({ style, children }) {
       return (

--- a/test/slider-test.jsx
+++ b/test/slider-test.jsx
@@ -46,6 +46,16 @@ describeWithDOM('<Slider />', () => {
       assert(wrapper.find('.rheostat-progress').length === 1, 'the bar is present');
     });
 
+    it('should render the slider with a tooltip for a single handle if enabled', () => {
+      const wrapper = shallow(<Slider values={[1]} handleTooltip />);
+      assert(wrapper.find('.rheostat-handle-tooltip').length === 1, 'the tooltip is present');
+    });
+
+    it('should render the slider with as many tooltips as values if enabled', () => {
+      const wrapper = shallow(<Slider values={[0, 25, 50, 75, 100]} handleTooltip />);
+      assert(wrapper.find('.rheostat-handle-tooltip').length === 5, 'five tooltips are present');
+    });
+
     it('renders pits if they are provided', () => {
       const pitRender = sinon.stub().returns(<div />);
       const PitComponent = createReactClass({


### PR DESCRIPTION
- Add tooltip that displays current value of slider while it's being dragged.
- Add an option to format tooltip value.
- Add tests to ensure tooltip rendering if enabled.
- Add story in storybook.
- Update README file with tooltip documentation and example.

#### Default tooltip:
![slider-tooltip](https://user-images.githubusercontent.com/12200583/41507456-5f7ec1c2-7250-11e8-98d8-018e4a9516ff.PNG)

#### Tooltip with formatted value:
![slider-tooltip-with-formatting](https://user-images.githubusercontent.com/12200583/41507520-5f85e802-7251-11e8-8354-59acdb140f44.PNG)

