### PR TITLE
[test] only run build script on latest node version (1/7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_install:
 install:
   - 'if [ "${TRAVIS_NODE_VERSION}" = "0.6" ] || [ "${TRAVIS_NODE_VERSION}" = "0.9" ]; then nvm install --latest-npm 0.8 && npm install && nvm use "${TRAVIS_NODE_VERSION}"; else npm install; fi;'
 script:
-  - 'if [ -n "${PRETEST-}" ]; then npm run pretest ; fi'
+  - 'if [ -n "${LINT-}" ]; then npm run lint ; fi'
+  - 'if [ -n "${BUILD-}" ]; then npm run build ; fi'
   - 'if [ -n "${POSTTEST-}" ]; then npm run posttest ; fi'
   - 'if [ -n "${COVERAGE-}" ]; then npm run test ; fi'
   - 'if [ -n "${TEST-}" ]; then npm run tests-only ; fi'
@@ -29,7 +30,9 @@ matrix:
   fast_finish: true
   include:
     - node_js: "lts/*"
-      env: PRETEST=true
+      env: LINT=true
+    - node_js: "lts/*"
+      env: BUILD=true
     - node_js: "lts/*"
       env: COVERAGE=true
   allow_failures:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "storybook": "start-storybook -p 9001",
     "pretest": "npm run build && npm run lint",
     "test": "nyc npm run test:all",
-    "tests-only": "npm run build && npm run test:all",
+    "tests-only": "npm run test:all",
     "pretest:all": "npm run react",
     "test:all": "npm run test:node && npm run test:dom",
     "test:node": "npm run jest -- --testEnvironment=node",


### PR DESCRIPTION
Fixes CI issue where build script was failing on Node 4. This is because buildCSS.js (which runs during the build process), included/had dependencies which use object destructuring, which is not supported by Node 4. 

To fix this, I introduced a change where build is only run once, and on the newest version of node.

This is required before 
https://github.com/airbnb/rheostat/pull/162
https://github.com/airbnb/rheostat/pull/163
https://github.com/airbnb/rheostat/pull/164

can be merged. 