### PR TITLE
[bugfix] reintroduce background prop

### DIFF
--- a/src/DefaultBackground.jsx
+++ b/src/DefaultBackground.jsx
@@ -23,11 +23,12 @@ function DefaultBackground({
 }) {
   return (
     <div
-      {...css((
-        orientation === VERTICAL
+      {...css(
+        styles.DefaultBackground,
+        (orientation === VERTICAL
           ? styles.DefaultBackground_background__vertical
-          : styles.DefaultBackground_background__horizontal
-      ))}
+          : styles.DefaultBackground_background__horizontal),
+      )}
     />
   );
 }
@@ -35,15 +36,19 @@ DefaultBackground.propTypes = propTypes;
 DefaultBackground.defaultProps = defaultProps;
 
 export default withStyles(({ rheostat: { color, unit } }) => ({
-  DefaultBackground_background: {
+  DefaultBackground: {
     backgroundColor: color.white,
-    border: `5px solid ${color.grey}`,
+    height: (2 * unit) - 1,
+    width: '100%',
+    border: `1px solid ${color.grey}`,
     position: 'relative',
   },
 
   DefaultBackground_background__horizontal: {
     height: (2 * unit) - 1,
-    top: 0,
+    top: -2,
+    left: -2,
+    bottom: 4,
     width: '100%',
   },
 

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import LinearScale from './algorithms/linear';
 import DefaultHandle from './DefaultHandle';
 import DefaultProgressBar from './DefaultProgressBar';
-
+import DefaultBackground from './DefaultBackground';
 import OrientationPropType from './propTypes/OrientationPropType';
 
 import {
@@ -43,6 +43,8 @@ const propTypes = forbidExtraProps({
     getValue: PropTypes.func,
     getPosition: PropTypes.func,
   }),
+
+  background: PropTypeReactComponent,
 
   // any children you pass in
   children: PropTypes.node,
@@ -128,6 +130,7 @@ const defaultProps = {
   pitPoints: [],
   snap: false,
   snapPoints: [],
+  background: DefaultBackground,
   handle: DefaultHandle,
   progressBar: DefaultProgressBar,
   values: [
@@ -748,6 +751,7 @@ class Rheostat extends React.Component {
       orientation,
       pitComponent: PitComponent,
       pitPoints,
+      background: Background,
       progressBar: ProgressBar,
       styles,
     } = this.props;
@@ -767,14 +771,17 @@ class Rheostat extends React.Component {
           orientation === VERTICAL && styles.rheostat__vertical,
         )}
       >
+        {
+          !!Background && (
+            <Background
+              orientation={orientation}
+            />
+          )
+        }
         <div
           ref={this.setHandleContainerNode}
           {...css(
             styles.handleContainer,
-            styles.rheostat_background,
-            orientation === VERTICAL
-              ? styles.rheostat_background__vertical
-              : styles.rheostat_background__horizontal,
           )}
         >
           {handlePos.map((pos, idx) => {
@@ -854,8 +861,12 @@ export default withStyles(({ rheostat: { color, unit, responsive } }) => ({
   },
 
   handleContainer: {
+    height: (2 * unit) - 1,
+    top: -2,
+    left: -2,
+    bottom: 4,
+    width: '100%',
     position: 'absolute',
-    top: '50%',
   },
 
   rheostat_background: {


### PR DESCRIPTION
During the port of the internal Rheostat component, the background prop was taken out and placed inline. This prop has been re-added, restoring previous functionality. 