### PR TITLE
Add back pitStyle cache and remove step prop

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -317,18 +317,14 @@ class Rheostat extends React.Component {
 
   getHandleDimensions() {
     const { orientation } = this.props;
+    if (!this.handleNode) return 0;
+
     return orientation === VERTICAL
       ? this.handleNode.clientHeight
       : this.handleNode.clientWidth;
   }
 
-  /*
-    During snap point animation, the actual position of the slider is required,
-    even though snap is labelled as true. Because of this, there is a
-    second param to optionally return the actual slider position, rather than
-    the closest snap point.
-  */
-  getSnapPosition(positionPercent, ignoreSnap = false) {
+  getSnapPosition(positionPercent) {
     const {
       algorithm,
       max,
@@ -336,7 +332,7 @@ class Rheostat extends React.Component {
       snap,
     } = this.props;
 
-    if (!snap || ignoreSnap) return positionPercent;
+    if (!snap) return positionPercent;
     const value = algorithm.getValue(positionPercent, min, max);
     const snapValue = this.getClosestSnapPoint(value);
     return algorithm.getPosition(snapValue, min, max);
@@ -533,7 +529,7 @@ class Rheostat extends React.Component {
     const sliderBox = this.getSliderBoundingBox();
     const positionPercent = this.positionPercent(x, y, sliderBox);
 
-    this.slideTo(idx, this.getSnapPosition(positionPercent, true));
+    this.slideTo(idx, positionPercent);
 
     if (this.canMove(idx, positionPercent)) {
       if (onSliderDragMove) onSliderDragMove();

--- a/src/constants/SliderConstants.js
+++ b/src/constants/SliderConstants.js
@@ -11,6 +11,5 @@ export const KEYS = {
 };
 export const PERCENT_EMPTY = 0;
 export const PERCENT_FULL = 100;
-export const DEFAULT_STEP = 1;
 export const HORIZONTAL = 'horizontal';
 export const VERTICAL = 'vertical';

--- a/test/slider-test.jsx
+++ b/test/slider-test.jsx
@@ -384,22 +384,6 @@ describe('Slider API', () => {
       assert(slider.getSnapPosition(96) === 100, 'position is at 100%');
       assert(slider.getSnapPosition(55) === 50, 'position is at 50%');
     });
-
-    /*
-      During slide, the animation requires getSnapPosition to not return
-      the position of the point, but rather the actual position of the slider.
-      This is accomplished with an extra arg to getSnapPosition.
-    */
-    it('should not return snap point when flag passed in', () => {
-      const slider = shallow(<Slider
-        snap
-        snapPoints={[0, 25, 50, 75, 100]}
-      />).dive().instance();
-
-      assert(slider.getSnapPosition(20, true) === 20, 'position is at 25%');
-      assert(slider.getSnapPosition(96, true) === 96, 'position is at 100%');
-      assert(slider.getSnapPosition(55, true) === 55, 'position is at 50%');
-    });
   });
 
   describe('getNextPositionForKey', () => {


### PR DESCRIPTION
A couple of things were modified in #161. One, we lost the pit style cache (#123, #130) and two there was a strange update to add `step` instead of `snap` (but step wasn't actually used anywhere). This change adds back the cache and also consolidates on the `snap` API (including a small fix to how position was being set).

I also opened https://github.com/airbnb/rheostat/issues/176 to track the issue that `step` was intended to address. 

to: @ljharb @philipfweiss @airbnb/webinfra 