### PR TITLE
Do not trigger change event when programmatically updating the slider values

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -742,7 +742,7 @@ class Rheostat extends React.Component {
     this.setState({
       handlePos: nextValues.map(value => algorithm.getPosition(value, min, max)),
       values: nextValues,
-    }, () => this.fireChangeEvent());
+    });
   }
 
   invalidatePitStyleCache() {

--- a/test/slider-test.jsx
+++ b/test/slider-test.jsx
@@ -155,12 +155,9 @@ describeWithDOM('<Slider />', () => {
     });
 
     it('should update values when they change', () => {
-      const onChange = sinon.spy();
-      const slider = shallow(<Slider onChange={onChange} values={[50]} />).dive();
+      const slider = shallow(<Slider values={[50]} />).dive();
 
       slider.setProps({ values: [80] });
-
-      assert.isTrue(onChange.calledOnce, 'updateNewValues was called');
 
       assert.include(slider.state('values'), 80, 'new value is reflected in state');
     });


### PR DESCRIPTION
Fixes #137

This no longer triggers the onChange handler when values (or min/max) are programmatically updated. I tested this on @madou's example repo: https://github.com/madou/rheostat-double-onchange/. Note that normal behavior continues as expected. The `updateNewValues` method only gets called by 1componentWillReceiveProps`.

to: @ljharb @airbnb/webinfra 