### PR TITLE
[fix] Move theme registration to src

### DIFF
--- a/.storybook-css/config.js
+++ b/.storybook-css/config.js
@@ -2,7 +2,7 @@ import { configure } from '@kadira/storybook';
 import ThemedStyleSheet from 'react-with-styles/lib/ThemedStyleSheet';
 import aphroditeInterface from 'react-with-styles-interface-aphrodite';
 import '../css/rheostat.css';
-import registerCSSInterfaceWithDefaultTheme from '../scripts/utils/registerCSSInterfaceWithDefaultTheme';
+import registerCSSInterfaceWithDefaultTheme from '../lib/utils/registerCSSInterfaceWithDefaultTheme';
 
 
 /* Register react with styles interface */

--- a/.storybook-css/config.js
+++ b/.storybook-css/config.js
@@ -2,7 +2,7 @@ import { configure } from '@kadira/storybook';
 import ThemedStyleSheet from 'react-with-styles/lib/ThemedStyleSheet';
 import aphroditeInterface from 'react-with-styles-interface-aphrodite';
 import '../css/rheostat.css';
-import registerCSSInterfaceWithDefaultTheme from '../lib/utils/registerCSSInterfaceWithDefaultTheme';
+import registerCSSInterfaceWithDefaultTheme from '../src/utils/registerCSSInterfaceWithDefaultTheme';
 
 
 /* Register react with styles interface */

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,7 @@
 import { configure } from '@kadira/storybook';
 import ThemedStyleSheet from 'react-with-styles/lib/ThemedStyleSheet';
 import aphroditeInterface from 'react-with-styles-interface-aphrodite';
-import registerInterfaceWithDefaultTheme from '../scripts/utils/registerInterfaceWithDefaultTheme';
+import registerInterfaceWithDefaultTheme from '../lib/utils/registerInterfaceWithDefaultTheme';
 
 /* Register react with styles interface */
 registerInterfaceWithDefaultTheme(aphroditeInterface);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,7 @@
 import { configure } from '@kadira/storybook';
 import ThemedStyleSheet from 'react-with-styles/lib/ThemedStyleSheet';
 import aphroditeInterface from 'react-with-styles-interface-aphrodite';
-import registerInterfaceWithDefaultTheme from '../lib/utils/registerInterfaceWithDefaultTheme';
+import registerInterfaceWithDefaultTheme from '../src/utils/registerInterfaceWithDefaultTheme';
 
 /* Register react with styles interface */
 registerInterfaceWithDefaultTheme(aphroditeInterface);

--- a/scripts/buildCSS.js
+++ b/scripts/buildCSS.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const CleanCSS = require('clean-css');
 const compileCSS = require('react-with-styles-interface-css-compiler');
 const registerMaxSpecificity = require('react-with-styles-interface-css/dist/utils/registerMaxSpecificity').default;
-const registerCSSInterfaceWithDefaultTheme = require('./utils/registerCSSInterfaceWithDefaultTheme').default;
+const registerCSSInterfaceWithDefaultTheme = require('../lib/utils/registerCSSInterfaceWithDefaultTheme').default;
 
 const args = process.argv.slice(2);
 const optimizeForProduction = args.includes('-o') || args.includes('--optimize');

--- a/scripts/utils/registerCSSInterfaceWithDefaultTheme.js
+++ b/scripts/utils/registerCSSInterfaceWithDefaultTheme.js
@@ -1,9 +1,5 @@
 /* This file should be removed in the next major version update of Rheostat */
 
-import CSSInterface from 'react-with-styles-interface-css';
+import registerCSSInterfaceWithDefaultTheme from '../../lib/utils/registerCSSInterfaceWithDefaultTheme';
 
-import registerInterfaceWithDefaultTheme from './registerInterfaceWithDefaultTheme';
-
-export default function registerCSSInterfaceWithDefaultTheme() {
-  registerInterfaceWithDefaultTheme(CSSInterface);
-}
+export default registerCSSInterfaceWithDefaultTheme;

--- a/scripts/utils/registerInterfaceWithDefaultTheme.js
+++ b/scripts/utils/registerInterfaceWithDefaultTheme.js
@@ -1,9 +1,5 @@
 /* This file should be removed in the next major version update of Rheostat */
 
-import ThemedStyleSheet from 'react-with-styles/lib/ThemedStyleSheet';
-import DefaultTheme from '../../src/themes/DefaultTheme';
+import registerInterfaceWithDefaultTheme from '../../lib/utils/registerInterfaceWithDefaultTheme';
 
-export default function registerInterfaceWithDefaultTheme(reactWithStylesInterface) {
-  ThemedStyleSheet.registerInterface(reactWithStylesInterface);
-  ThemedStyleSheet.registerTheme(DefaultTheme);
-}
+export default registerInterfaceWithDefaultTheme;

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -1,3 +1,3 @@
-import registerCSSInterfaceWithDefaultTheme from '../scripts/utils/registerCSSInterfaceWithDefaultTheme';
+import registerCSSInterfaceWithDefaultTheme from './utils/registerCSSInterfaceWithDefaultTheme';
 
 registerCSSInterfaceWithDefaultTheme();

--- a/src/utils/.eslintrc
+++ b/src/utils/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "import/no-extraneous-dependencies": [2, {
+      "devDependencies": true
+    }],
+  }
+}

--- a/src/utils/.eslintrc
+++ b/src/utils/.eslintrc
@@ -1,7 +1,0 @@
-{
-  "rules": {
-    "import/no-extraneous-dependencies": [2, {
-      "devDependencies": true
-    }],
-  }
-}

--- a/src/utils/registerCSSInterfaceWithDefaultTheme.js
+++ b/src/utils/registerCSSInterfaceWithDefaultTheme.js
@@ -1,5 +1,3 @@
-/* This file should be removed in the next major version update of Rheostat */
-
 import CSSInterface from 'react-with-styles-interface-css';
 
 import registerInterfaceWithDefaultTheme from './registerInterfaceWithDefaultTheme';

--- a/src/utils/registerInterfaceWithDefaultTheme.js
+++ b/src/utils/registerInterfaceWithDefaultTheme.js
@@ -1,7 +1,5 @@
-/* This file should be removed in the next major version update of Rheostat */
-
 import ThemedStyleSheet from 'react-with-styles/lib/ThemedStyleSheet';
-import DefaultTheme from '../../src/themes/DefaultTheme';
+import DefaultTheme from '../themes/DefaultTheme';
 
 export default function registerInterfaceWithDefaultTheme(reactWithStylesInterface) {
   ThemedStyleSheet.registerInterface(reactWithStylesInterface);


### PR DESCRIPTION
Addresses https://github.com/airbnb/rheostat/issues/181. Moves the theme registration helper functions into src, so they will be compiled during the build step. Also updates the callsites of these functions to point into `lib/utils/<x>`, as desired. 

Keeps a copy of these files in `scripts/utils` as well, for backwards-compatibility. These files should be removed at the next major version update. 