### PR TITLE
Fix date example to work with IOS

### DIFF
--- a/stories/ExampleSlider.jsx
+++ b/stories/ExampleSlider.jsx
@@ -129,8 +129,8 @@ storiesOf('Slider', module)
     );
   })
   .add('Dates', () => {
-    const startDate = new Date('01-01-2015').valueOf();
-    const endDate = new Date('12-31-2015').valueOf();
+    const startDate = new Date(2015, 1, 1).valueOf();
+    const endDate = new Date(2015, 12, 31).valueOf();
     const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
     function ordinal(n) {


### PR DESCRIPTION
Date example does not work in Safari and IOS devices:
![bug](http://joxi.ru/BA0on6QFMXaJx2.jpg)