### PR TITLE
Rename unsafe lifecycle method

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -196,7 +196,7 @@ class Rheostat extends React.Component {
     }, 0);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const {
       disabled,
       min,

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -7,10 +7,3 @@ configure();
 
 ThemedStyleSheet.registerTheme(DefaultTheme);
 ThemedStyleSheet.registerInterface(aphroditeInterface);
-
-function skipError(arg) {
-  return arg && /^Warning: componentWillReceiveProps has been renamed,/.test(arg);
-}
-
-console.error = (arg) => { if (!skipError(arg)) { throw new Error(arg); } };
-console.warn = (arg) => { if (!skipError(arg)) { throw new Error(arg); } };


### PR DESCRIPTION
Ran `npx react-codemod rename-unsafe-lifecycles`.

Removes "Warning: componentWillReceiveProps has been renamed" errors.