### PR TITLE
[fix][deps] `react-with-styles` 4.0.0 -> 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "object.assign": "^4.1.0",
     "prop-types": "^15.7.2",
     "react-with-direction": "^1.3.1",
-    "react-with-styles": "^4.0.0",
+    "react-with-styles": "^4.0.1",
     "react-with-styles-interface-css": "^6.0.0"
   },
   "jest": {


### PR DESCRIPTION
### Summary

Updates the version of `react-with-styles` from 4.0.0 to 4.0.1, which uses a `WeakMap` for caching of stylesFn results to avoid high memory usage.

### Reviewers

@ljharb @majapw @ahuth @TaeKimJR @indiesquidge @joeuy 