### PR TITLE
Add Touch Events to Callbacks

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -464,14 +464,14 @@ class Rheostat extends React.Component {
     this.setStartSlide(ev, ev.clientX, ev.clientY);
 
     if (typeof document.addEventListener === 'function') {
-      document.addEventListener('mousemove', this.handleMouseSlide, false);
-      document.addEventListener('mouseup', this.endSlide, false);
+      document.addEventListener('mousemove', this.handleMouseSlide, {passive: false});
+      document.addEventListener('mouseup', this.endSlide, {passive: false});
     } else {
       document.attachEvent('onmousemove', this.handleMouseSlide);
       document.attachEvent('onmouseup', this.endSlide);
     }
 
-    if (onSliderDragStart) onSliderDragStart();
+    if (onSliderDragStart) onSliderDragStart(ev);
 
     killEvent(ev);
   }
@@ -485,10 +485,10 @@ class Rheostat extends React.Component {
 
     this.setStartSlide(ev, touch.clientX, touch.clientY);
 
-    document.addEventListener('touchmove', this.handleTouchSlide, false);
-    document.addEventListener('touchend', this.endSlide, false);
+    document.addEventListener('touchmove', this.handleTouchSlide, {passive: false});
+    document.addEventListener('touchend', this.endSlide, {passive: false});
 
-    if (onSliderDragStart) onSliderDragStart();
+    if (onSliderDragStart) onSliderDragStart(ev);
 
     killEvent(ev);
   }


### PR DESCRIPTION
This PR adds touchevents to the onSliderDragStart callback. This is useful so we can control touch events through rheostat.

An example would be blocking rheostat from scrolling vertically on mobile while it's dragging. Currently if a user uses our rheostat component on mobile, they can drag the slider and scroll the page at the same time.

Also added the current passive: false touch listeners to remove the warning from chrome.