### PR TITLE
[Slider] Fix "TypeError: Cannot read 'getBoundingClientRect' of null"

### DIFF
--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -259,6 +259,10 @@ class Rheostat extends React.Component {
   }
 
   getSliderBoundingBox() {
+    if (!this.handleContainerNode) {
+      return null;
+    }
+
     const rect = this.handleContainerNode.getBoundingClientRect();
     return {
       height: rect.height || this.handleContainerNode.clientHeight,
@@ -448,6 +452,10 @@ class Rheostat extends React.Component {
 
   setStartSlide(ev) {
     const sliderBox = this.getSliderBoundingBox();
+    if (!sliderBox) {
+      return;
+    }
+
     this.setState({
       handleDimensions: this.getHandleDimensions(ev, sliderBox),
       slidingIndex: getHandleFor(ev),
@@ -532,7 +540,12 @@ class Rheostat extends React.Component {
   handleSlide(x, y) {
     const { onSliderDragMove } = this.props;
     const { slidingIndex: idx } = this.state;
+
     const sliderBox = this.getSliderBoundingBox();
+    if (!sliderBox) {
+      return;
+    }
+
     const positionPercent = this.positionPercent(x, y, sliderBox);
 
     this.slideTo(idx, positionPercent);
@@ -587,6 +600,9 @@ class Rheostat extends React.Component {
     // Calculate the position of the slider on the page so we can determine
     // the position where you click in relativity.
     const sliderBox = this.getSliderBoundingBox();
+    if (!sliderBox) {
+      return;
+    }
 
     const positionDecimal = orientation === VERTICAL
       ? (ev.clientY - sliderBox.top) / sliderBox.height
@@ -696,6 +712,9 @@ class Rheostat extends React.Component {
     } = this.state;
     const { orientation } = this.props;
     const sliderBox = this.getSliderBoundingBox();
+    if (!sliderBox) {
+      return false;
+    }
 
     const handlePercentage = orientation === VERTICAL
       ? ((handleDimensions / sliderBox.height) * PERCENT_FULL) / 2

--- a/test/slider-test.jsx
+++ b/test/slider-test.jsx
@@ -240,6 +240,13 @@ describeWithDOM('<Slider />', () => {
       assert(slider.state('handlePos').length === 2, 'two handles exist');
     });
   });
+
+  describe('getSliderBoundingBox', () => {
+    it('returns null if the ref to the handle container node is not yet set', () => {
+      const slider = shallow(<Slider />).dive().dive().instance();
+      assert.isNull(slider.getSliderBoundingBox(), 'handle container ref is not yet set');
+    });
+  });
 });
 
 describe('Slider API', () => {
@@ -626,6 +633,12 @@ describe('Slider API', () => {
         sinon.stub(slider, 'getSliderBoundingBox').returns(sliderBoundingBox);
 
         assert.isTrue(slider.canMove(0, 40), 'sure you can move here');
+      });
+
+      it('should return false if the ref to the handle container node is not yet set', () => {
+        const slider = shallow(<Slider values={[50]} />).dive().dive().instance();
+        assert.isUndefined(slider.handleContainerNode, 'ref is not available');
+        assert.isFalse(slider.canMove(0, 40), 'ref is not available');
       });
     });
   });


### PR DESCRIPTION
I couldn't repro this error, but I think this should fix it.

```js
TypeError: null is not an object (evaluating 'this.handleContainerNode.getBoundingClientRect')
  at getSliderBoundingBox (./node_modules/rheostat/lib/Slider.js:325)
  at None ([native code])
  at touch (./node_modules/rheostat/lib/Slider.js:704)
  at None ([native code])
  at this (./node_modules/rheostat/lib/Slider.js:677)
...
(2 additional frame(s) were not displayed)
```

By protecting access to `this.handleContainerNode`, we avoid this issue completely.

@ljharb @lencioni 

Airbnb internal ticket: PRODUCT-49741