### PR TITLE
Implements autoFocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ your own as long as it conforms to the shape.
   })
 ```
 
+AutoFocus on handle. If multiple handles are used, it focuses on the first one.
+
+```js
+  autoFocus: PropTypes.bool
+```
+
 Custom class name that will be applied to the root of Rheostat.
 
 ```js

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -39,6 +39,9 @@ const propTypes = forbidExtraProps({
   // Automatically adds a top position for large when enabled
   autoAdjustVerticalPosition: PropTypes.bool,
 
+  // Automatically sets focus on handle
+  autoFocus: PropTypes.bool,
+
   // the algorithm to use
   algorithm: PropTypes.shape({
     getValue: PropTypes.func,
@@ -109,6 +112,7 @@ const propTypes = forbidExtraProps({
 
 const defaultProps = {
   autoAdjustVerticalPosition: false,
+  autoFocus: false,
   children: null,
   algorithm: LinearScale,
   disabled: false,
@@ -778,6 +782,7 @@ class Rheostat extends React.Component {
     const {
       css,
       autoAdjustVerticalPosition,
+      autoFocus,
       algorithm,
       children,
       disabled,
@@ -831,6 +836,7 @@ class Rheostat extends React.Component {
                 aria-valuemin={this.getMinValue(idx)}
                 aria-valuenow={values[idx]}
                 aria-disabled={disabled}
+                autoFocus={autoFocus && idx === 0}
                 data-handle-key={idx}
                 key={idx /* eslint-disable-line react/no-array-index-key */}
                 orientation={orientation}

--- a/stories/ExampleSlider.jsx
+++ b/stories/ExampleSlider.jsx
@@ -66,6 +66,9 @@ storiesOf('Slider', module)
   .add('A Simple Slider', () => (
     <LabeledSlider />
   ))
+  .add('Handle autoFocus', () => (
+    <LabeledSlider autoFocus />
+  ))
   .add('Custom Handle', () => {
     function MyHandle({ style, handleRef, ...passProps }) {
       return (


### PR DESCRIPTION
AutoFocus is an important accessibility issue. Currently, there is no way to implement in Rheostat - the handle ref is not forwarded and because custom handles are provided as render functions, overriding the `ref` is not easy.

This PR implements and `autoFocus` prop, consistent with the property name found in HTML input fields. 

If multiple handles are used, focus is given to the first one. 