### PR TITLE
Fix jest test match glob so all test files are picked up

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   },
   "jest": {
     "testMatch": [
-      "<rootDir>/test/*-test.*"
+      "<rootDir>/test/**/*-test.*"
     ],
     "setupFiles": [
       "<rootDir>/test/_helpers/setupFiles.js"


### PR DESCRIPTION
geometric-test.js was being missed from the test run.

before
![Screen Shot 2020-05-19 at 6 33 20 pm](https://user-images.githubusercontent.com/2787876/82304125-40238000-99ff-11ea-843f-ce3d2a57ad4c.png)

after
![Screen Shot 2020-05-19 at 6 33 08 pm](https://user-images.githubusercontent.com/2787876/82304147-46b1f780-99ff-11ea-876e-7283928ea71d.png)
