### PR TITLE
remove unnecessary var from numerator and denominator in geometic equation and tidy up /algorithm code

### DIFF
--- a/src/algorithms/geometric.js
+++ b/src/algorithms/geometric.js
@@ -1,9 +1,10 @@
+const POWER = 2;
 export default {
   getPosition(value, min, max) {
-    return ((value - min) / (max - min)) ** 0.5 * 100;
+    return ((value - min) / (max - min)) ** (1 / POWER) * 100;
   },
 
   getValue(positionPercent, min, max) {
-    return (Math.round(((positionPercent / 100) ** 2) * (max - min)) + min);
+    return (Math.round(((positionPercent / 100) ** POWER) * (max - min)) + min);
   },
 };

--- a/src/algorithms/geometric.js
+++ b/src/algorithms/geometric.js
@@ -1,6 +1,6 @@
 export default {
   getPosition(x, min, max) {
-    return ((max / (max - min)) ** 0.5) * (((x - min) / max) ** 0.5) * 100;
+    return ((x - min) / (max - min)) ** 0.5 * 100;
   },
 
   getValue(x, min, max) {

--- a/src/algorithms/geometric.js
+++ b/src/algorithms/geometric.js
@@ -1,9 +1,9 @@
 export default {
-  getPosition(x, min, max) {
-    return ((x - min) / (max - min)) ** 0.5 * 100;
+  getPosition(value, min, max) {
+    return ((value - min) / (max - min)) ** 0.5 * 100;
   },
 
-  getValue(x, min, max) {
-    return (Math.round(((x / 100) ** 2) * (max - min)) + min);
+  getValue(positionPercent, min, max) {
+    return (Math.round(((positionPercent / 100) ** 2) * (max - min)) + min);
   },
 };

--- a/src/algorithms/geometric.js
+++ b/src/algorithms/geometric.js
@@ -1,3 +1,4 @@
+// y = x^2
 const POWER = 2;
 export default {
   getPosition(value, min, max) {

--- a/src/algorithms/linear.js
+++ b/src/algorithms/linear.js
@@ -1,3 +1,4 @@
+// y = x
 export default {
   getPosition(value, min, max) {
     return ((value - min) / (max - min)) * 100;

--- a/src/algorithms/linear.js
+++ b/src/algorithms/linear.js
@@ -3,14 +3,14 @@ export default {
     return ((value - min) / (max - min)) * 100;
   },
 
-  getValue(pos, min, max) {
-    const decimal = pos / 100;
+  getValue(positionPercent, min, max) {
+    const decimal = positionPercent / 100;
 
-    if (pos === 0) {
+    if (positionPercent === 0) {
       return min;
     }
 
-    if (pos === 100) {
+    if (positionPercent === 100) {
       return max;
     }
 


### PR DESCRIPTION
There is an unnecessary var being used in the geometric equation, I've removed it and tidied up the code. Note there are tests to cover the geometric equation, them passing helps prove it's the same equation with this var removed.

Here is some handwritten maths explaining why the `max` need not live at the top and bottom of the fraction, it just cancels out. I start with what we used to have and finish with what this PR changes to.

![IMG_20200521_171308](https://user-images.githubusercontent.com/2787876/82535005-886ea980-9b89-11ea-98cf-accc890e7915.jpg)
