### PR TITLE
Assign disabled class to defaultProgressBar

### DIFF
--- a/src/DefaultProgressBar.jsx
+++ b/src/DefaultProgressBar.jsx
@@ -45,7 +45,7 @@ function DefaultProgressBar({
             styles.DefaultProgressBar_background__horizontal,
           ]),
 
-        disabled && styles.progressBar_disabled,
+        disabled && styles.DefaultProgressBar__disabled,
         style,
       )}
       {...passProps}
@@ -80,5 +80,9 @@ export default withStyles(({ rheostat: { color, unit } }) => ({
   DefaultProgressBar_background__horizontal: {
     height: (2 * unit) - 3,
     top: 0,
+  },
+
+  DefaultProgressBar__disabled: {
+    borderColor: color.progressBar.defaultDisabledColor,
   },
 }))(DefaultProgressBar);


### PR DESCRIPTION
It looks like DefaultProgressBar wasn't assigning a disabled class name for `disabled` prop. 

I've updated it to mirror the DefaultHandle class naming pattern and now progress bar correctly applies `DefaultProgressBar__disabled` class name when `disabled` prop is `true`.


#### Before
<img width="1451" alt="Screenshot 2021-02-04 at 17 45 31" src="https://user-images.githubusercontent.com/12280422/106917660-26eb6c80-6711-11eb-904c-bbda92ec5c71.png">

#### After
<img width="1463" alt="Screenshot 2021-02-04 at 17 45 47" src="https://user-images.githubusercontent.com/12280422/106917672-294dc680-6711-11eb-8ac0-d6f70fdd5ee0.png">

