### PR TITLE
[RTL - Demo] hard code the leadingDirection

### DIFF
--- a/src/DefaultHandle.jsx
+++ b/src/DefaultHandle.jsx
@@ -82,6 +82,7 @@ export default withStyles(({ rheostat: { color, unit, constants } }) => ({
   },
 
   DefaultHandle_handle__horizontal: {
+    // TODO this should reverse to marginRight: -12 in the RTL context?
     marginLeft: -12,
     top: -5,
     ':before': {

--- a/src/Slider.jsx
+++ b/src/Slider.jsx
@@ -274,15 +274,16 @@ class Rheostat extends React.Component {
   }
 
   getProgressStyle(idx) {
-    const { orientation } = this.props;
+    const { direction, orientation } = this.props;
     const { handlePos } = this.state;
 
     const value = handlePos[idx];
+    const leadingDirection = direction === DIRECTIONS.RTL ? 'right' : 'left';
 
     if (idx === 0) {
       return orientation === VERTICAL
         ? { height: `${value}%`, top: 0 }
-        : { left: 0, width: `${value}%` };
+        : { [leadingDirection]: 0, width: `${value}%` };
     }
 
     const prevValue = handlePos[idx - 1];
@@ -290,7 +291,7 @@ class Rheostat extends React.Component {
 
     return orientation === VERTICAL
       ? { height: `${diffValue}%`, top: `${prevValue}%` }
-      : { left: `${prevValue}%`, width: `${diffValue}%` };
+      : { [leadingDirection]: `${prevValue}%`, width: `${diffValue}%` };
   }
 
   getMinValue(idx) {
@@ -593,6 +594,7 @@ class Rheostat extends React.Component {
     }
 
     const {
+      direction,
       onClick,
       orientation,
     } = this.props;
@@ -604,9 +606,12 @@ class Rheostat extends React.Component {
       return;
     }
 
-    const positionDecimal = orientation === VERTICAL
+    let positionDecimal = orientation === VERTICAL
       ? (ev.clientY - sliderBox.top) / sliderBox.height
       : (ev.clientX - sliderBox.left) / sliderBox.width;
+    if (direction === DIRECTIONS.RTL && orientation === HORIZONTAL) {
+      positionDecimal = 1 - positionDecimal;
+    }
 
     const positionPercent = positionDecimal * PERCENT_FULL;
 
@@ -780,6 +785,7 @@ class Rheostat extends React.Component {
       autoAdjustVerticalPosition,
       algorithm,
       children,
+      direction,
       disabled,
       handle: Handle,
       max,
@@ -821,9 +827,10 @@ class Rheostat extends React.Component {
           )}
         >
           {handlePos.map((pos, idx) => {
+            const leadingDirection = direction === DIRECTIONS.RTL ? 'right' : 'left';
             const handleStyle = orientation === VERTICAL
               ? { top: `${pos}%`, position: 'absolute' }
-              : { left: `${pos}%`, position: 'absolute' };
+              : { [leadingDirection]: `${pos}%`, position: 'absolute' };
 
             return (
               <Handle

--- a/stories/ExampleSlider.jsx
+++ b/stories/ExampleSlider.jsx
@@ -321,6 +321,7 @@ storiesOf('Slider', module)
         border: '1px solid #890f00',
         borderRadius: '100%',
         cursor: 'ew-resize',
+        // TODO shouldn't this reverse to marginRight in the RTL context
         marginLeft: -13,
         height: 24,
         width: 24,


### PR DESCRIPTION
RTL support isn't working if you follow the [Live Playground](https://github.com/airbnb/rheostat#live-playground) storybook steps and click around in the RTL Stories. 

![Rheostat RTL example](https://user-images.githubusercontent.com/7050871/212139994-d1b7ce72-e34d-467d-8f00-5d899cfbe001.gif)

This PR manually changes the `left` to `right` [when the CSS is calculated in JS](https://github.com/airbnb/rheostat/pull/290/files#diff-5c1dfa9c9d42a2ad64c8e9523139677de5fd50f53003ee81366fb13c49637e32L285), but it cannot change the `left` to `right` [in the R-W-S CSS](https://github.com/airbnb/rheostat/pull/290/files#diff-fa580031261b2bf5cc512aa3b5b76ee8c029ec5522f4428cf4fad74bb273300bR325). 

**The root cause of [this existing RTL issue](https://github.com/airbnb/rheostat/issues/282) is that the `left` to `right` CSS styles are not being auto-flipped**, which [this introductory PR's comment](https://github.com/airbnb/rheostat/pull/235#discussion_r309876723) suggests was working correctly at some point. There have been multiple RTL PRs made and I suspect RTL was working at those times, but it is no longer working. I don't think we should merge this PR, but it is highlighting that the left/right auto-flipping is not happening as expected.